### PR TITLE
Fix 404 errors with API update

### DIFF
--- a/entsog/decorators.py
+++ b/entsog/decorators.py
@@ -3,7 +3,7 @@ from socket import gaierror
 from time import sleep
 import requests
 from functools import wraps
-from .exceptions import NoMatchingDataError, PaginationError, BadGatewayError, TooManyRequestsError
+from .exceptions import NoMatchingDataError, PaginationError, BadGatewayError, TooManyRequestsError, NotFoundError
 import pandas as pd
 import logging
 
@@ -64,6 +64,9 @@ def documents_limited(n):
                     frames.append(frame)
                 except NoMatchingDataError:
                     logging.debug(f"NoMatchingDataError: for offset {offset}")
+                    break
+                except NotFoundError:
+                    logging.debug(f"NotFoundError: for offset {offset}")
                     break
 
             if len(frames) == 0:

--- a/entsog/entsog.py
+++ b/entsog/entsog.py
@@ -406,8 +406,7 @@ class EntsogRawClient:
         return response.text, response.url
 
     def query_operator_point_directions(self,
-                                        country_code: Union[Country, str] = None,
-                                        has_data: int = 1) -> str:
+                                        country_code: Union[Country, str] = None) -> str:
 
         """
         
@@ -417,7 +416,6 @@ class EntsogRawClient:
         Parameters
         ----------
         country_code : Union[Country, str]
-        has_data : int
 
         Returns
         -------
@@ -504,9 +502,7 @@ class EntsogRawClient:
         "dataSet"
         -----------------
         """
-        params = {
-            'hasData': has_data
-        }
+        params = {}
         if country_code is not None:
             params['tSOCountry'] = lookup_country(country_code).code
 
@@ -1437,8 +1433,7 @@ class EntsogPandasClient(EntsogRawClient):
         return data
 
     def query_operator_point_directions(self,
-                                        country_code: Optional[Union[Country, str]] = None,
-                                        has_data: int = 1) -> pd.DataFrame:
+                                        country_code: Optional[Union[Country, str]] = None) -> pd.DataFrame:
 
         """
         
@@ -1448,7 +1443,6 @@ class EntsogPandasClient(EntsogRawClient):
         Parameters
         ----------
         country Union[Area, str]
-        has_data int
 
         Returns
         -------
@@ -1457,7 +1451,7 @@ class EntsogPandasClient(EntsogRawClient):
         if country_code is not None:
             country_code = lookup_country(country_code)
         json, url = super(EntsogPandasClient, self).query_operator_point_directions(
-            country_code=country_code, has_data=has_data
+            country_code=country_code
         )
         data = parse_operator_points_directions(json)
         data['url'] = url

--- a/entsog/entsog.py
+++ b/entsog/entsog.py
@@ -8,7 +8,7 @@ import pytz
 import requests
 
 from .decorators import *
-from .exceptions import GatewayTimeOut, UnauthorizedError, BadGatewayError, TooManyRequestsError
+from .exceptions import GatewayTimeOut, UnauthorizedError, BadGatewayError, TooManyRequestsError, NotFoundError
 from .mappings import Area, lookup_area, Indicator, lookup_balancing_zone, lookup_country, lookup_indicator, Country, BalancingZone
 from .parsers import *
 
@@ -96,6 +96,8 @@ class EntsogRawClient:
                 raise GatewayTimeOut
             elif response.status_code == 429:
                 raise TooManyRequestsError
+            elif response.status_code == 404:
+                raise NotFoundError
             else:        
                 raise e
         else:
@@ -109,6 +111,8 @@ class EntsogRawClient:
                     raise BadGatewayError
                 elif response.status_code == 429:
                     raise TooManyRequestsError
+                elif response.status_code == 404:
+                    raise NotFoundError
 
             return response
 

--- a/entsog/exceptions.py
+++ b/entsog/exceptions.py
@@ -15,3 +15,6 @@ class TooManyRequestsError(Exception):
 
 class GatewayTimeOut(Exception):
     pass
+
+class NotFoundError(Exception):
+    pass


### PR DESCRIPTION
The recent changes to the ENTSOG API have impacted how certain queries return results. I've identified two main issues:

## Operational Data Queries with Offset:
Previously, querying operational data with an offset would return a 500 error, as expected. Now, it returns a 404 error, which broke the way the library handles end of data. You can reproduce this issue using this [URL](https://transparency.entsog.eu/api/v1/operationaldatas?limit=1000&offset=10000).

## Disabled hasData Parameter for Operator Point Directions:
The hasData parameter has been disabled when querying for Operator Point Directions, and setting this parameter now results in a 404 error. You can reproduce this issue using this [URL](https://transparency.entsog.eu/api/v1/operatorpointdirections?hasData=1).

# Changes Made

This pull request addresses issue #17 with the following changes:

- Added handling for 404 errors in the library.
- Removed the hasData parameter from the operator_point_directions methods.

These changes ensure the library correctly handles the new API behavior and prevents errors during data retrieval.